### PR TITLE
Update : syn-wrte 동시성 부분 해결

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,10 @@
     "name": "pintos-dev",
     "dockerFile": "Dockerfile",
     "remoteUser": "jungle",
+    // "runArgs": [
+    //     "--cpus=0.2",
+    //     "--memory=512m"
+    // ],
     "customizations": {
         "vscode": {
             "extensions": [

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # custom
 .test_status
+.while_test_status
 
 ### Linux ###
 *~

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -7,7 +7,8 @@
             ],
             "defines": [
                 "USERPROG",
-                "FILESYS"
+                "FILESYS",
+                "VM"
             ],
             "compilerPath": "/usr/bin/gcc",
             "cStandard": "c11",

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -518,6 +518,7 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->magic = THREAD_MAGIC;
 
 	t->exit_status = 0;
+	t->current_file = NULL;
 	list_init (&t->process_child_list);
 	sema_init (&t->exit_sema, 0);
 	sema_init (&t->fork_sema, 0);

--- a/pintos/userprog/while_test.sh
+++ b/pintos/userprog/while_test.sh
@@ -1,0 +1,10 @@
+# CHOICE=76
+
+for test in {1..95}; do
+    for i in {1..5}; do
+        make clean
+        make
+        res="$(printf "%s\n" "$test" | bash select_test.sh -q | grep -E '^(PASS|FAIL)$')"
+        echo "run=$i test=$test result=${res:-NONE}" >> .while_test_status
+    done
+done


### PR DESCRIPTION
# 파일 싱크 부분 해결
- 파일 관련 작업을 할때, 싱크가 서로 틀어지는 문제를 해결하였습니다.
- 파일 관련을 작업할때 lock을 이용하여서 동시성 문제를 해결하였습니다.
- open 할때 동시에 여는 것이 아닌, lock을 통해 동시가 아닌 요청 순서마다 lock을 해서 순차적으로 open 하도록 수정하였습니다.
- 또한, 파일 관련 함수도 중첩 if문이 아닌, 사람이 보기 쉽게 if return 문으로 수정하였습니다.
# 반복 테스트 .sh 파일 추가
- 테스트를 반복하여서 정말 통과되는지 확인해야하는 경우가 생기는데, 이를 쉽게하기 위해 테스트를 반복하여서 결과를 출력해주는 while_test.sh 파일을 추가하였습니다.
# VM 챕터에 따른 c_cpp_properties.json 파일 업데이트
- VM 챕터로 넘어가는 만큼 vscode에서 작업할때, 작업환경을 위해 전처리기 매크로에 VM 키워드를 추가하였습니다.