### PR TITLE
add : vm_alloc_page_with_initializer 함수 추가 및 spt_find_page 함수 추가

### DIFF
--- a/pintos/include/vm/vm.h
+++ b/pintos/include/vm/vm.h
@@ -46,9 +46,10 @@ struct page {
 	const struct page_operations *operations;
 	void *va;              /* Address in terms of user space */
 	struct frame *frame;   /* Back reference for frame */
-
+	
 	/* Your implementation */
-	struct aux aux;
+	struct hash_elem hash_elem; /* For supplemental page table */
+	bool is_writable;
 
 	/* Per-type data are binded into the union.
 	 * Each function automatically detects the current union */
@@ -60,8 +61,6 @@ struct page {
 		struct page_cache page_cache;
 #endif
 	};
-
-	struct hash_elem hash_elem; /* For supplemental page table */
 };
 
 /* The representation of "frame" */

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -982,20 +982,16 @@ load_segment (struct file *file, off_t ofs, uint8_t *upage,
 		 * and zero the final PAGE_ZERO_BYTES bytes. */
 		size_t page_read_bytes = read_bytes < PGSIZE ? read_bytes : PGSIZE;
 		size_t page_zero_bytes = PGSIZE - page_read_bytes;
-
-		/* TODO: Set up aux to pass information to the lazy_load_segment. */
-		struct aux *aux = (struct aux *)malloc(sizeof (struct aux));
+		struct aux *aux = malloc(sizeof (struct aux));
+		
 		aux->file = file;
 		aux->ofs = ofs;
 		aux->page_read_bytes = page_read_bytes;
 
-		if (!vm_alloc_page_with_initializer (VM_ANON, upage,
-					writable, lazy_load_segment, aux)) {
+		if (!vm_alloc_page_with_initializer (VM_ANON, upage, writable, lazy_load_segment, aux)) {
 			free(aux);
 			return false;
 		}
-
-		free(aux);
 
 		/* Advance. */
 		read_bytes -= page_read_bytes;


### PR DESCRIPTION
# spt_find_page 함수 추가
- spt에서 va에 해당하는 page가 있는지 확인하는 함수를 추가하였습니다.
- 기본적으로 spt의 hash에서 페이지를 구분하기 위한 key는 va로 정했습니다.
- pintos에서 hash 자료구조는 list처럼 침투형 자료구조이기 때문에, 만약 hash에서 어떤 page를 찾으려면, page 객체가 있어야 합니다.
- 때문에 임시 객체인 temp_page 를 만들고, 거기에 va를 대입한 다음 해당 temp_page 로 hash_find을 하면, 해당 va에 맞는 page가 있는지 찾을 수 있게 됩니다.
- 이를 통해 반환값이 page_elem 에 NULL을 반환하면, page를 insert 한 적이 없다는 뜻이니까 NULL을 반환하고, page_elem에 어떠한 주소가 있다면 해당하는 page가 있다는 뜻이니까 hash_entry로 해당 page 주소를 반환합니다.
#  vm_alloc_page_with_initializer 함수 추가
- spt_find_page 함수로 해당 va에 대한 페이지가 없다면, 새로운 page를 만들어서 spt의 hash에 insert 합니다.
- 페이지가 아직 초기화 되지 않은 상태를 나타내는 VM_UNINIT 으로 page를 초기화 하려는 거기 때문에, 어떤 타입으로 전환할지(VM_ANON, VM_FILE)에 대한 정보와 추가적으로 필요한 정보인 aux를 uninit_new에 넣어서 VM_UNINIT 페이지를 생성합니다.
- 이후 hash_insert를 통해 최종적으로 새로 만든 page를 hash에 넣게 됩니다.