### PR TITLE
add/lazy load 로직 추가

### DIFF
--- a/pintos/include/vm/vm.h
+++ b/pintos/include/vm/vm.h
@@ -67,12 +67,14 @@ struct page {
 struct frame {
 	void *kva;
 	struct page *page;
+	struct list_elem elem;
 };
 
-struct aux {
+struct load_arg {
 	struct file *file;
 	off_t ofs;
 	size_t page_read_bytes;
+	size_t page_zero_bytes;
 };
 
 /* The function table for page operations.

--- a/pintos/vm/anon.c
+++ b/pintos/vm/anon.c
@@ -31,6 +31,8 @@ anon_initializer (struct page *page, enum vm_type type, void *kva) {
 	page->operations = &anon_ops;
 
 	struct anon_page *anon_page = &page->anon;
+
+	return true;
 }
 
 /* Swap in the page by read contents from the swap disk. */


### PR DESCRIPTION
# vm_try_handle_fault 함수 로직 추가
- page_fault로 발생할때, 해결을 위해 핸들러 하는 vm_try_handle_fault 함수에 로직을 추가하였습니다.
- 들어온 주소가 유저 영역인지, 해당 주소에 맞는 spt가 있는지, 그리고 쓰기가 금지되어 있는데 쓰기를 요청했는지에 따라 체크를 하며, 최종적으로 문제가 없을 경우 실제 frame 할당과 pml4에 매핑을 위해 vm_do_claim_page 함수를 호출하게 만들었습니다.
# vm_get_frame 함수 로직 추가
- 실제 frame 할당을 하기 위한 함수입니다.
- 유저 풀에서 palloc을 시도하며, 만약 palloc을 실패할 경우, evict 하는 로직을 추가해야 합니다. (미구현)
- 이후 해당 palloc에 대응하는 frame을 생성하고 frame_list에 push 합니다.
# vm_do_claim_page 함수 로직 추가
- 준비된 page와 frame을 서로 연결하고, page에 불러올 데이터를 frame에 등록된 palloc에 swap_in(여기서는 uninit_initialize 함수)을 시도합니다.
# lazy_load_segment 함수 로직 추가
- 실질적으로 파일의 정보를 frame에 입력하는 함수입니다.
- uninit에서 함수포인터인 init에 lazy_load_segment 를 등록하였기 때문에, uninit_initialize 함수가 실행될때 동작하게 됩니다.
- 로직자체는 유저 프로그램 때의 load_segment와 동일합니다.