### PR TITLE
page_hash_func, page_less_func 구현

### DIFF
--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -71,28 +71,37 @@ err:
 
 /* Find VA from spt and return page. On error, return NULL. */
 struct page *
-spt_find_page(struct supplemental_page_table *spt UNUSED, void *va UNUSED)
+spt_find_page(struct supplemental_page_table *spt, void *va)
 {
-	struct page *page = NULL;
-	/* TODO: Fill this function. */
-
-	return page;
+	struct page pp;
+	pp.va = pg_round_down(va);
+	struct hash_elem *e = hash_find(&spt->hash, &pp.hash_elem);
+	if (e == NULL)
+		return NULL;
+	struct page *p = hash_entry(e, struct page, hash_elem);
+	return p;
+	/*
+	spt에 해당 va가 해당하는 페이지 엔트리가 있나를 조회하는 함수
+	*/
 }
-
 /* Insert PAGE into spt with validation. */
-bool spt_insert_page(struct supplemental_page_table *spt UNUSED,
-					 struct page *page UNUSED)
+bool spt_insert_page(struct supplemental_page_table *spt,
+					 struct page *page)
 {
-	int succ = false;
-	/* TODO: Fill this function. */
+	page->va = pg_round_down(page->va);
+	struct hash_elem *old = hash_insert(&spt->hash, &page->hash_elem);
 
-	return succ;
+	return old == NULL;
+	/*
+	spt안에 page를 등록하는 기능
+	*/
 }
 
 void spt_remove_page(struct supplemental_page_table *spt, struct page *page)
 {
+	hash_delete(&spt->hash, &page->hash_elem);
 	vm_dealloc_page(page);
-	return true;
+	// spt에서 해당 페이지 제거
 }
 
 /* Get the struct frame, that will be evicted. */
@@ -197,7 +206,7 @@ void supplemental_page_table_init(struct supplemental_page_table *spt UNUSED)
 static unsigned
 page_hash_func(const struct hash_elem *e, void *aux)
 {
-	struct page *p = hash_entry(e, struct page, h_elem);
+	struct page *p = hash_entry(e, struct page, hash_elem);
 	void *key = pg_round_down(p->va);
 	return hash_bytes(&key, sizeof key);
 	/* 페이지의 va를 해시값으로 사용 : va를 페이지의 시작 주소로 rounding 해야 함 (offset 제거 필요)
@@ -208,8 +217,8 @@ page_hash_func(const struct hash_elem *e, void *aux)
 static bool
 page_less_func(const struct hash_elem *a, const struct hash_elem *b, void *aux)
 {
-	struct page *pa = hash_entry(a, struct page, h_elem);
-	struct page *pb = hash_entry(b, struct page, h_elem);
+	struct page *pa = hash_entry(a, struct page, hash_elem);
+	struct page *pb = hash_entry(b, struct page, hash_elem);
 	return pg_round_down(pa->va) < pg_round_down(pb->va);
 	/* 페이지의 va를 기준으로 비교 */
 	/*


### PR DESCRIPTION
### page_hash_func
struct page의 va를 해시 키로 사용하여 해시 값을 계산하는 함수입니다.
입력: struct hash_elem * (페이지의 해시 요소)
출력: 해당 페이지의 가상 주소를 기반으로 한 hash 값

### page_less_func
두 struct page 객체의 va를 비교하여 순서를 결정하는 함수입니다.
입력: struct hash_elem *a, struct hash_elem *b
출력: pa->va < pb->va이면 true, 그렇지 않으면 false
용도: 해시 테이블 내부에서 정렬 또는 충돌 해소 시 비교 기준으로 사용