### PR TITLE
add : stack growth 기능 구현

### DIFF
--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -134,6 +134,7 @@ struct thread {
 	/* Table for whole virtual memory owned by thread. */
 	struct supplemental_page_table spt;
 	void *stack_bottom;
+	uintptr_t user_rsp;
 #endif
 
 	/* Owned by thread.c. */

--- a/pintos/include/threads/vaddr.h
+++ b/pintos/include/threads/vaddr.h
@@ -37,6 +37,8 @@
 /* User stack start */
 #define USER_STACK 0x47480000
 
+#define USER_STACK_MAX 0x47380000
+
 /* Returns true if VADDR is a user virtual address. */
 #define is_user_vaddr(vaddr) (!is_kernel_vaddr((vaddr)))
 

--- a/pintos/userprog/exception.c
+++ b/pintos/userprog/exception.c
@@ -143,6 +143,7 @@ page_fault (struct intr_frame *f) {
 
 #ifdef VM
 	/* For project 3 and later. */
+	if (user == true) thread_current ()->user_rsp = f->rsp;
 	if (vm_try_handle_fault (f, fault_addr, user, write, not_present))
 		return;
 #endif

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -412,6 +412,7 @@ __do_fork (void *aux) {
 	process_activate (current);
 #ifdef VM
 	current->stack_bottom = parent->stack_bottom;
+	current->user_rsp = parent->user_rsp;
 	supplemental_page_table_init (&current->spt);
 	if (!supplemental_page_table_copy (&current->spt, &parent->spt))
 		goto error;
@@ -1026,6 +1027,7 @@ load_segment (struct file *file, off_t ofs, uint8_t *upage,
 /* Create a PAGE of stack at the USER_STACK. Return true on success. */
 static bool
 setup_stack (struct intr_frame *if_) {
+	struct thread *curr = thread_current ();
 	void *stack_bottom = (void *) (((uint8_t *) USER_STACK) - PGSIZE);
 	bool success = false;
 
@@ -1035,7 +1037,8 @@ setup_stack (struct intr_frame *if_) {
 	if (!vm_claim_page (stack_bottom))
 		goto done;
 
-	thread_current ()->stack_bottom = stack_bottom;
+	curr->stack_bottom = stack_bottom;
+	curr->user_rsp = USER_STACK;
 	if_->rsp = USER_STACK;
 
 	success = true;

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -198,6 +198,8 @@ process_file_read (int fd, void *buffer, unsigned size) {
 	node = process_check_fd (fd);
 	if (node == NULL)
 		return -1;
+	if (spt_find_page (&thread_current ()->spt, buffer)->is_writable == false)
+		sys_exit (-1);
 	
 	if (node->type == FD_FILE)
 		return file_read (node->file, buffer, size);

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -182,8 +182,11 @@ vm_get_frame (void) {
 }
 
 /* Growing the stack. */
-static void
+static bool
 vm_stack_growth (void *addr UNUSED) {
+	if (!vm_alloc_page_with_initializer (VM_ANON | VM_MARKER_STACK, addr, true, NULL, NULL))
+		return false;
+	return true;
 }
 
 /* Handle the fault on write_protected page */
@@ -195,37 +198,38 @@ vm_handle_wp (struct page *page UNUSED) {
 bool
 vm_try_handle_fault (struct intr_frame *f UNUSED, void *addr UNUSED,
 		bool user UNUSED, bool write UNUSED, bool not_present UNUSED) {
-	struct supplemental_page_table *spt UNUSED = &thread_current ()->spt;
+	struct thread *curr = thread_current ();
+	struct supplemental_page_table *spt = &curr->spt;
 	struct page *page = NULL;
 
-	if (is_kernel_vaddr (addr))
-		return false;
-	
-	page = spt_find_page (spt, addr);
-	if (page == NULL)
+	if (addr == NULL || is_kernel_vaddr (addr))
 		return false;
 
-	if (page->is_writable == false && write == true)
-		return false;
-
-	// 스택 성장 조건도 확인
+	if (not_present == false) {
+        // cow 기능 구현하기. 지금은 무조건 false
+        return false;
+    }
 	
-	return vm_do_claim_page (page);
+	if ((page = spt_find_page (spt, addr)) != NULL) {
+		if (page->is_writable == false && write == true)
+			return false;
+		else
+			return vm_do_claim_page (page);
+	}
+
+	if (user == true && addr == (curr->user_rsp - 8) && addr >= USER_STACK_MAX) {
+		curr->stack_bottom -= PGSIZE;
+		return vm_stack_growth (curr->stack_bottom);
+	}
+
+	return false;
 }
 
 /* Free the page.
  * DO NOT MODIFY THIS FUNCTION. */
 void
 vm_dealloc_page (struct page *page) {
-	struct frame *delete_frame = page->frame;
-
-	if (delete_frame != NULL) {
-		list_remove (&delete_frame->elem);
-		free (delete_frame);
-	}
-	
 	destroy (page);
-	
 	free (page);
 }
 


### PR DESCRIPTION
# read할때, buffer가 write 가능한 주소인지 체크하는 코드 추가
- read할때, buffer로 write를 하면 안되는 주소에 작성되는걸 방지하기 위해 if문을 추가하였습니다.
# spt 의 hash를 비우는 함수 수정
- hash를 비울때, 몇가지 코드를 수정하였습니다.
- 먼저 spt_remove_page 함수를 추가하였습니다. 나중에 사용하기 위해 특정 spt에서 특정 elem을 삭제할때를 대비하기 위함입니다.
- frame을 free 해주는 기능을 vm_free_frame 함수로 뻈습니다. 두 곳에서 frame의 free를 요청하기때문에, 함수 하나로 관리하기 위해 vm_free_frame 함수를 추가하였습니다.
# stack growth 기능 구현
- 스택을 확장하는 기능을 구현하였습니다.
- 스택의 확장 조건인 (user == true && addr == (curr->user_rsp - 8) && addr >= USER_STACK_MAX) 에 부합한지 체크한 다음, 부합하다면 현재 stack_bottom 에서 1페이지 만큼만 추가하도록 하였습니다.
- 1페이지만 해도 문제없는게, true로 반환하면 해당 폴트를 계속 시도하기때문에 결국 계속해서 1페이지씩 확장하게 되고 결국 addr 까지 확장하게 됩니다.